### PR TITLE
세션 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
 	// AOP
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+	implementation 'org.springframework.session:spring-session-jdbc:3.2.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/pilot/instagram/domain/user/UserController.java
+++ b/src/main/java/pilot/instagram/domain/user/UserController.java
@@ -23,13 +23,10 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ApiResponse<String> login(@Valid @RequestBody UserRequest userRequest, HttpSession session) {
-        session.setAttribute("user", userRequest.getId());
-        return ApiResponse.of(HttpStatus.OK, session.getId());
-    }
-
-    @GetMapping("/test")
-    public String test(HttpSession httpSession) {
-        return httpSession.getAttribute("user").toString();
+    public ApiResponse<UserResponse> login(@Valid @RequestBody UserRequest userRequest, HttpSession session) {
+        UserResponse userResponse = userService.login(userRequest.getId());
+        session.setAttribute("userId", userRequest.getId());
+        // session.getAttribute("userId") 로 userId를 세션에서 가져올 수 있음
+        return ApiResponse.of(HttpStatus.OK, userResponse);
     }
 }

--- a/src/main/java/pilot/instagram/domain/user/UserController.java
+++ b/src/main/java/pilot/instagram/domain/user/UserController.java
@@ -1,12 +1,10 @@
 package pilot.instagram.domain.user;
 
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import pilot.instagram.global.ApiResponse;
 import pilot.instagram.domain.user.request.UserRequest;
 import pilot.instagram.domain.user.response.UserResponse;
@@ -22,5 +20,16 @@ public class UserController {
     @PostMapping("/new")
     public ApiResponse<UserResponse> saveUser(@Valid @RequestBody UserRequest userRequest) {
         return ApiResponse.of(HttpStatus.CREATED, userService.saveUser(userRequest));
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<String> login(@Valid @RequestBody UserRequest userRequest, HttpSession session) {
+        session.setAttribute("user", userRequest.getId());
+        return ApiResponse.of(HttpStatus.OK, session.getId());
+    }
+
+    @GetMapping("/test")
+    public String test(HttpSession httpSession) {
+        return httpSession.getAttribute("user").toString();
     }
 }

--- a/src/main/java/pilot/instagram/domain/user/service/UserService.java
+++ b/src/main/java/pilot/instagram/domain/user/service/UserService.java
@@ -21,7 +21,13 @@ public class UserService {
         return UserResponse.of(userRepository.save(User.fromDtoToUser(userRequest)));
     }
 
+    public UserResponse login(String id) {
+        User user = userRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("아이디를 찾을 수 없습니다"));
+        return UserResponse.of(user);
+    }
+
     private void validateDuplicateId(String id) {
-        userRepository.findById(id).ifPresent(user -> {throw new IllegalArgumentException("DUPLICATE_ID");});
+        userRepository.findById(id).ifPresent(user -> {throw new IllegalArgumentException("중복된 아이디입니다.");});
     }
 }

--- a/src/main/java/pilot/instagram/domain/user/service/UserService.java
+++ b/src/main/java/pilot/instagram/domain/user/service/UserService.java
@@ -28,6 +28,6 @@ public class UserService {
     }
 
     private void validateDuplicateId(String id) {
-        userRepository.findById(id).ifPresent(user -> {throw new IllegalArgumentException("중복된 아이디입니다.");});
+        userRepository.findById(id).ifPresent(user -> {throw new IllegalArgumentException("중복된 아이디입니다");});
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,3 +13,13 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: none
+  session:
+    timeout: 600
+    store-type: jdbc
+    jdbc:
+      initialize-schema: always
+      table-name: SPRING_SESSION
+    jpa:
+      defer-datasource-initialization: true
+      open-in-view: false
+      generate-ddl: true

--- a/src/test/java/pilot/instagram/user/UserControllerTest.java
+++ b/src/test/java/pilot/instagram/user/UserControllerTest.java
@@ -76,7 +76,7 @@ public class UserControllerTest {
 
         // when, then
         userService.saveUser(userRequest);
-        doThrow(new IllegalArgumentException("DUPLICATE_ID"))
+        doThrow(new IllegalArgumentException("중복된 아이디입니다"))
                 .when(userService).saveUser(argThat(req -> req.getId().equals(id)));
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/user/new")
@@ -86,7 +86,7 @@ public class UserControllerTest {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("DUPLICATE_ID"));
+                .andExpect(jsonPath("$.message").value("중복된 아이디입니다"));
     }
 
 }

--- a/src/test/java/pilot/instagram/user/UserServiceTest.java
+++ b/src/test/java/pilot/instagram/user/UserServiceTest.java
@@ -63,6 +63,37 @@ public class UserServiceTest {
         userService.saveUser(userRequest);
         assertThatThrownBy(() -> userService.saveUser(userRequest))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("DUPLICATE_ID");
+                .hasMessage("중복된 아이디입니다");
+    }
+
+    @Test
+    @DisplayName("회원가입 된 계정으로 로그인을 한다.")
+    void loginWithSavedAccount() {
+        //given
+        String id = UUID.randomUUID().toString();
+        usedIds.add(id);
+        UserRequest userRequest = UserRequest.builder().id(id).name("이기태").build();
+
+        //when
+        UserResponse userResponse = userService.saveUser(userRequest);
+
+        //then
+        assertThat(userResponse.getId()).isNotNull();
+        assertThat(userResponse.getId()).isEqualTo(id);
+        assertThat(userResponse.getName()).isEqualTo("이기태");
+    }
+
+    @Test
+    @DisplayName("회원가입 안된 계정으로 로그인은 불가능하다.")
+    void loginWithUnsavedAccount() {
+        //given
+        String id = UUID.randomUUID().toString();
+        usedIds.add(id);
+        UserRequest userRequest = UserRequest.builder().id(id).name("이기태").build();
+
+        //when //then
+        assertThatThrownBy(() -> userService.login(userRequest.getId()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("아이디를 찾을 수 없습니다");
     }
 }


### PR DESCRIPTION
실제 서비스를 출시하는 것이 아닌, 개인 프로젝트이므로 Spring Security + JWT 토큰의 로그인 방식보단 간단한 스프링 세션 방식으로 로그인 기능을 구현했습니다.

[스프링에서 제공하는 SESSION 관련 테이블 추가]
![image](https://github.com/user-attachments/assets/307ea13e-a06a-4243-bf32-2e86c0570536)

User의 id를 세션에 담아두고 
`session.getAttribute("userId")` 의 방식으로 User의 id를 세션에서 뽑아와 다른 엔티티의 fk로 사용하면 될듯합니다.
포스트맨 및 테스트 케이스로 테스트 완료했습니다:)