### PR TITLE
Jacoco 라이브러리를 통한 테스트 커버리지 측정 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.6'
+	id 'jacoco'
 }
 
 group = 'pilot'
@@ -44,8 +45,36 @@ dependencies {
 	// AOP
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+	// Session
 	implementation 'org.springframework.session:spring-session-jdbc:3.2.1'
 }
+
+jacoco {
+	toolVersion = "0.8.9"
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		xml.required.set(true)
+		html.required.set(true)
+
+		afterEvaluate {
+			classDirectories.setFrom(files(classDirectories.files.collect {
+				fileTree(dir: it, include: '**/service/**')
+			}))
+		}
+
+		xml.destination file("${buildDir}/jacoco/index.xml")
+		html.destination file("${buildDir}/jacoco/index.html")
+	}
+}
+/** Jacoco end **/
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/test/java/pilot/instagram/user/UserServiceTest.java
+++ b/src/test/java/pilot/instagram/user/UserServiceTest.java
@@ -75,7 +75,8 @@ public class UserServiceTest {
         UserRequest userRequest = UserRequest.builder().id(id).name("이기태").build();
 
         //when
-        UserResponse userResponse = userService.saveUser(userRequest);
+        userService.saveUser(userRequest);
+        UserResponse userResponse = userService.login(userRequest.getId());
 
         //then
         assertThat(userResponse.getId()).isNotNull();


### PR DESCRIPTION
Jacoco 라이브러리를 통해 테스트 커버리지를 측정할 수 있도록 구현했습니다.
비즈니스 로직에만 테스트를 집중하면 좋을 것 같아 `**/service/**` 디렉토리 밑에 있는 코드만 측정하도록 세팅해줬습니다.

**[Jacoco를 통한 테스트 커버리지 예시]**
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/4c6d0b3b-e1f8-4e0a-a58a-fd00b143a109">
<img width="454" alt="image" src="https://github.com/user-attachments/assets/e6e15935-a5ad-4d7a-89d7-11301a0b1719">

**[기존 테스트 케이스 수정사항]**
기존에 user 관련한 테스트 중에서 "로그인" 테스트 이지만 "회원가입" 테스트로 코드가 잘못 짜져있었습니다.
그래서 밑에 사진처럼 테스트 커버리지에서 로그인에 대한 성공 케이스에 대해 `missed instruction` 이 나온 걸 볼 수 있습니다.
이를 인지하고 회원가입 -> 로그인으로 테스트를 수정했고 위의 사진들처럼 테스트 커버리지가 100% 나왔습니다.
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/bd89a4fc-97a6-487a-85ec-95a8b1234039">