### PR TITLE
QueryDSL를 사용한 내가 쓴 게시글 리스트 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### QClass ###
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,20 @@ tasks.named('test') {
 	useJUnitPlatform()
 }
 
+// Querydsl 빌드 옵션 설정
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
 clean {
-	delete file('src/main/generated')
+	delete file(generated)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 
 	// Session
 	implementation 'org.springframework.session:spring-session-jdbc:3.2.1'
+
+	//Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 jacoco {
@@ -78,4 +84,8 @@ jacocoTestReport {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/src/main/java/pilot/instagram/config/QueryDSLConfig.java
+++ b/src/main/java/pilot/instagram/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package pilot.instagram.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/pilot/instagram/config/SpringDataJsonConfig.java
+++ b/src/main/java/pilot/instagram/config/SpringDataJsonConfig.java
@@ -1,0 +1,10 @@
+package pilot.instagram.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
+
+public class SpringDataJsonConfig {
+}

--- a/src/main/java/pilot/instagram/domain/post/PostController.java
+++ b/src/main/java/pilot/instagram/domain/post/PostController.java
@@ -3,9 +3,12 @@ package pilot.instagram.domain.post;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import pilot.instagram.domain.post.dto.request.PostRequest;
+import pilot.instagram.domain.post.dto.response.PostPagingResponse;
 import pilot.instagram.domain.post.dto.response.PostResponse;
 import pilot.instagram.domain.post.service.PostService;
 import pilot.instagram.global.ApiResponse;
@@ -26,5 +29,11 @@ public class PostController {
     @GetMapping("/{postId}")
     public ApiResponse<PostResponse> getPost(@PathVariable("postId") Long postId) {
         return ApiResponse.of(HttpStatus.OK, postService.getPost(postId));
+    }
+
+    @GetMapping("/myPostList")
+    public ApiResponse<Page<PostPagingResponse>> getPosts(HttpSession session, Pageable pageable) {
+        String userId = session.getAttribute("userId").toString();
+        return ApiResponse.of(HttpStatus.OK, postService.getPosts(userId, pageable));
     }
 }

--- a/src/main/java/pilot/instagram/domain/post/dto/response/PostPagingResponse.java
+++ b/src/main/java/pilot/instagram/domain/post/dto/response/PostPagingResponse.java
@@ -1,0 +1,10 @@
+package pilot.instagram.domain.post.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class PostPagingResponse {
+    private Long id;
+    private String content;
+    private String userId;
+}

--- a/src/main/java/pilot/instagram/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/pilot/instagram/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,9 @@
+package pilot.instagram.domain.post.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import pilot.instagram.domain.post.dto.response.PostPagingResponse;
+
+public interface PostCustomRepository {
+    Page<PostPagingResponse> findPostByUserIdWithPaged(String userId, Pageable pageable);
+}

--- a/src/main/java/pilot/instagram/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/pilot/instagram/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,51 @@
+package pilot.instagram.domain.post.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import pilot.instagram.domain.post.dto.response.PostPagingResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+import static ch.qos.logback.core.util.StringUtil.isNullOrEmpty;
+import static pilot.instagram.domain.post.entity.QPost.post;
+
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<PostPagingResponse> findPostByUserIdWithPaged(String userId, Pageable pageable) {
+        List<PostPagingResponse> fetchResult = jpaQueryFactory
+                .select(Projections.fields(PostPagingResponse.class,
+                        post.id.as("id"),
+                        post.content.as("content"),
+                        post.user.id.as("userId")))
+                .from(post)
+                .where(userIdEq(userId))
+                .orderBy(post.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(
+                        jpaQueryFactory
+                                .select(post.count())
+                                .from(post)
+                                .where(userIdEq(userId))
+                                .fetchOne())
+                .orElse(0L);
+
+        return PageableExecutionUtils.getPage(fetchResult, pageable, () -> total);
+    }
+
+    private BooleanExpression userIdEq(String userId) {
+        return isNullOrEmpty(userId) ? null : post.user.id.eq(userId);
+    }
+}

--- a/src/main/java/pilot/instagram/domain/post/repository/PostRepository.java
+++ b/src/main/java/pilot/instagram/domain/post/repository/PostRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 import pilot.instagram.domain.post.entity.Post;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
 }

--- a/src/main/java/pilot/instagram/domain/post/service/PostService.java
+++ b/src/main/java/pilot/instagram/domain/post/service/PostService.java
@@ -1,9 +1,12 @@
 package pilot.instagram.domain.post.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pilot.instagram.domain.post.dto.request.PostRequest;
+import pilot.instagram.domain.post.dto.response.PostPagingResponse;
 import pilot.instagram.domain.post.dto.response.PostResponse;
 import pilot.instagram.domain.post.entity.Post;
 import pilot.instagram.domain.post.repository.PostRepository;
@@ -30,5 +33,9 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException(ErrorCode.POST_NOT_FOUND.getMessage()));
         return PostResponse.of(post);
+    }
+
+    public Page<PostPagingResponse> getPosts(String userId, Pageable pageable) {
+        return postRepository.findPostByUserIdWithPaged(userId, pageable);
     }
 }


### PR DESCRIPTION
[추가 환경 설정 세팅 방법]
QueryDSL에서 사용하는 QClass를 사용하기 위해 추가 환경 세팅이 필요합니다.
![image](https://github.com/user-attachments/assets/b97df464-fc64-4b68-8af0-472c896dcbc3)
사진처럼 Gradle의 clean -> build 순서대로 진행해주시면 됩니다.
![image](https://github.com/user-attachments/assets/ef406db6-c9d9-47a9-b4a6-775f661eefc3)
그러면 사진처럼 src->main->generated 밑에 QClass 관련 엔티티들이 생성되어있는 것을 확인하셨다면 됩니다.
이 QClass는 git에는 안올리는걸 권장한다고하여 gitignore로 commit 되지 않도록 관리해야합니다.

[페이징 결과 공유]
나머지는 QueryDSL로 기본 Repository 세팅 및 Paging에 구현을 초점을 맞추고 진행했습니다.
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/5a5eb554-6824-429d-9b4d-8bcebf19d55f">