### PR TITLE
게시글 삭제 API 구현

### DIFF
--- a/src/main/java/pilot/instagram/domain/post/PostController.java
+++ b/src/main/java/pilot/instagram/domain/post/PostController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import pilot.instagram.domain.post.dto.request.PostRequest;
+import pilot.instagram.domain.post.dto.response.PostDeleteResponse;
 import pilot.instagram.domain.post.dto.response.PostPagingResponse;
 import pilot.instagram.domain.post.dto.response.PostResponse;
 import pilot.instagram.domain.post.service.PostService;
@@ -35,5 +36,11 @@ public class PostController {
     public ApiResponse<Page<PostPagingResponse>> getPosts(HttpSession session, Pageable pageable) {
         String userId = session.getAttribute("userId").toString();
         return ApiResponse.of(HttpStatus.OK, postService.getPosts(userId, pageable));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiResponse<PostDeleteResponse> deletePost(@PathVariable("postId") Long postId, HttpSession session) {
+        String userId = session.getAttribute("userId").toString();
+        return ApiResponse.of(HttpStatus.OK, postService.deletePost(postId, userId));
     }
 }

--- a/src/main/java/pilot/instagram/domain/post/dto/response/PostDeleteResponse.java
+++ b/src/main/java/pilot/instagram/domain/post/dto/response/PostDeleteResponse.java
@@ -1,0 +1,21 @@
+package pilot.instagram.domain.post.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import pilot.instagram.domain.post.entity.Post;
+
+@Getter
+public class PostDeleteResponse {
+    private Long id;
+
+    @Builder
+    private PostDeleteResponse(Long id) {
+        this.id = id;
+    }
+
+    public static PostDeleteResponse of(Post post) {
+        return PostDeleteResponse.builder()
+                .id(post.getId())
+                .build();
+    }
+}

--- a/src/main/java/pilot/instagram/domain/post/service/PostService.java
+++ b/src/main/java/pilot/instagram/domain/post/service/PostService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pilot.instagram.domain.post.dto.request.PostRequest;
+import pilot.instagram.domain.post.dto.response.PostDeleteResponse;
 import pilot.instagram.domain.post.dto.response.PostPagingResponse;
 import pilot.instagram.domain.post.dto.response.PostResponse;
 import pilot.instagram.domain.post.entity.Post;
@@ -37,5 +38,16 @@ public class PostService {
 
     public Page<PostPagingResponse> getPosts(String userId, Pageable pageable) {
         return postRepository.findPostByUserIdWithPaged(userId, pageable);
+    }
+
+    @Transactional
+    public PostDeleteResponse deletePost(Long postId, String userId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException(ErrorCode.POST_NOT_FOUND.getMessage()));
+        if(!post.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException(ErrorCode.UNAUTHORIZED_POST_DELETE.getMessage());
+        }
+        postRepository.delete(post);
+        return PostDeleteResponse.of(post);
     }
 }

--- a/src/main/java/pilot/instagram/exception/ErrorCode.java
+++ b/src/main/java/pilot/instagram/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     USER_NOT_FOUND("아이디를 찾을 수 없습니다"),
 
     // POST
-    POST_NOT_FOUND("게시글을 찾을 수 없습니다.");
+    POST_NOT_FOUND("게시글을 찾을 수 없습니다."),
+    UNAUTHORIZED_POST_DELETE("게시글 삭제 권한이 없습니다.");
 
     private final String message;
 }


### PR DESCRIPTION
  💌 전달사항
- 게시글 삭제 API를 구현했습니다.  #13 

### 🧩 사용 예시
[실패 예시]
1. 게시글 id 불일치
<img width="541" alt="스크린샷 2024-11-26 오전 5 31 03" src="https://github.com/user-attachments/assets/23f20820-c7dc-43e4-85ad-e8caf0bb86d7">

2. 작성자 불일치 (게시글 생성자와 다른 계정으로 로그인된 상태에서 삭제 시도)
<img width="526" alt="스크린샷 2024-11-26 오전 5 37 04" src="https://github.com/user-attachments/assets/1dfa4d7a-4dcf-4f5e-b1b8-efa73ff20103">

[성공 사례]
<img width="535" alt="스크린샷 2024-11-26 오전 5 35 20" src="https://github.com/user-attachments/assets/d1390ef9-6f74-439a-bddc-abac6acb6233">

### ⚙️ 기타사항
일반 프로젝트라면 게시글 같은 성격의 엔티티는 `SOFT DELETE` 방식을 채택했겠지만 현재 프로젝트의 경우 간단하게 `HARD DELETE` 방식으로 우선 설계 및 구현했습니다. 추후에 게시글 삭제와 더불어 `비공개` 라는 기능까지 생각한다면 컬럼을 하나 추가해 '공개/비공개/삭제' 등으로 운영하면 좋을 것 같습니다. 우선 지금은 단순하게 WIKI에 있는 삭제라고 생각해주시면 되고, 추후 명세서 설계 후에 고쳐야할 부분이 있으면 고치도록 하겠습니다:)
